### PR TITLE
Document shortcut commands for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ stateDiagram-v2
 ```
 
 Players take action by sending `GameMessage` objects to `WerewolfMachine` as appropriate.
+
+## Usage
+
+Run the interactive demo:
+
+```bash
+python src/werewolf.py
+```
+
+At the prompt, enter one of the following commands:
+
+- `next` (`n`) – toggle between Night and Day
+- `finish` (`f`) – end the game
+- `quit` (`q`) – exit the demo

--- a/src/werewolf.py
+++ b/src/werewolf.py
@@ -72,13 +72,20 @@ class WerewolfMachine(StateMachine):
 
 
 async def stdin_reader(machine: WerewolfMachine) -> None:
-    """
-    Command line interface for the Werewolf game.
+    """Command line interface for the Werewolf game.
+
+    Accepts the following commands (shortcuts in parentheses):
+
+    - ``next`` (``n``) – advance Night ↔ Day
+    - ``finish`` (``f``) – end the game
+    - ``quit`` (``q``) – exit the loop without a transition
 
     :param machine: Werewolf state machine
     """
     loop = asyncio.get_running_loop()
-    print("\nType commands: `next`, `finish`, `quit`. Ctrl+C to exit.\n")
+    print(
+        "\nType commands: `next` (n), `finish` (f), `quit` (q). Ctrl+C to exit.\n"
+    )
     print("Initial state:", machine.current_state.id)
 
     while True:
@@ -96,7 +103,7 @@ async def stdin_reader(machine: WerewolfMachine) -> None:
             await machine.handle_message(GameMessage(command=Command.QUIT))
             break
         else:
-            print("Unknown command. Use: next | finish | quit")
+            print("Unknown command. Use: next|n | finish|f | quit|q")
 
         if machine.current_state.final:
             print("SM: finished; exiting.")


### PR DESCRIPTION
## Summary
- mention `n`, `f`, and `q` shorthand commands in the interactive prompt
- document these shortcuts in `stdin_reader` docstring and README usage

## Testing
- `python -m pytest`
- `pip install pydantic==1.10.13 statemachine==0.8.0` *(fails: Cannot connect to proxy)*
- `python src/werewolf.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python - <<'PY' ... PY` (runs `stdin_reader` with stubs, help text shown)


------
https://chatgpt.com/codex/tasks/task_e_68a0cd1c679c832b8e5ab84f32723e70