### PR TITLE
Fix Day entry message spacing

### DIFF
--- a/src/werewolf.py
+++ b/src/werewolf.py
@@ -48,7 +48,7 @@ class WerewolfMachine(StateMachine):
         print("🌅 Exiting Night → transitioning...")
 
     def on_enter_day(self):
-        print("☀️  Entered Day. (Discussion, accusations, and voting.)")
+        print("☀️ Entered Day. (Discussion, accusations, and voting.)")
 
     def on_exit_day(self):
         print("🌘 Exiting Day → transitioning...")


### PR DESCRIPTION
## Summary
- remove extra space after sun emoji in Day entry message

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cd19c8f0832b8c549c75cb3a06a1