### PR TITLE
Add basic state machine unit test

### DIFF
--- a/test/test_werewolf.py
+++ b/test/test_werewolf.py
@@ -1,0 +1,16 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from werewolf import WerewolfMachine, GameMessage, Command
+
+
+@pytest.mark.asyncio
+async def test_state_machine_completes_cleanly():
+    machine = WerewolfMachine()
+    await machine.handle_message(GameMessage(command=Command.NEXT))
+    await machine.handle_message(GameMessage(command=Command.NEXT))
+    await machine.handle_message(GameMessage(command=Command.FINISH))
+    assert machine.current_state.final


### PR DESCRIPTION
## Summary
- add asynchronous unit test for werewolf state machine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a0d1199aa4832ba3092ed0d29266a6