### PR TITLE
Add Werewolf game state domain model

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Domain model representing the complete Werewolf game state."""
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, computed_field
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class Phase(StrEnum):
+    """Game phases."""
+
+    NIGHT = "night"
+    DAY = "day"
+
+
+class Role(StrEnum):
+    """Roles that players may take."""
+
+    WEREWOLF = "werewolf"
+    SEER = "seer"
+    VILLAGER = "villager"
+    DOCTOR = "doctor"
+
+
+class Winner(StrEnum):
+    """Final game state."""
+
+    WEREWOLVES = "werewolves"
+    VILLAGERS = "villagers"
+    NONE = "none"
+
+
+PlayerId = str
+
+
+class WerewolfState(BaseModel):
+    """Pydantic model holding the entire game state."""
+
+    day: int = 1
+    phase: Phase = Phase.NIGHT
+    roles: dict[PlayerId, Role]
+    alive_players: set[PlayerId] | None = None
+    known_roles: dict[PlayerId, dict[PlayerId, Role]] = {}
+
+    def model_post_init(self, __context: Any) -> None:
+        """Default ``alive_players`` to all players if not provided."""
+        if self.alive_players is None:
+            self.alive_players = set(self.roles.keys())
+
+    @computed_field
+    @property
+    def winner(self) -> Winner:
+        """Determine the current winner.
+
+        Villagers win when no werewolves remain alive. Werewolves win when
+        their count is equal to or exceeds the number of non-werewolf players
+        still alive. Otherwise, no side has won yet.
+        """
+        alive_roles = [self.roles[player] for player in self.alive_players]
+        werewolves = sum(1 for role in alive_roles if role == Role.WEREWOLF)
+        non_werewolves = len(alive_roles) - werewolves
+
+        if werewolves == 0:
+            return Winner.VILLAGERS
+        if werewolves >= non_werewolves:
+            return Winner.WEREWOLVES
+        return Winner.NONE

--- a/src/werewolf.py
+++ b/src/werewolf.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from pydantic import BaseModel
 from statemachine import State, StateMachine
+
+from state import WerewolfState
 import typer
 
 
@@ -40,6 +42,9 @@ class WerewolfMachine(StateMachine):
     # Transitions
     next = night.to(day) | day.to(night)
     finish = night.to(finished_state) | day.to(finished_state)
+
+    def __init__(self, state: WerewolfState | None = None) -> None:
+        super().__init__(model=state)
 
     # Hooks
     def on_enter_night(self):
@@ -112,7 +117,8 @@ async def stdin_reader(machine: WerewolfMachine) -> None:
 
 
 async def _async_main() -> None:
-    machine = WerewolfMachine()
+    state = WerewolfState(roles={})
+    machine = WerewolfMachine(state)
     await stdin_reader(machine)
 
 


### PR DESCRIPTION
## Summary
- add `WerewolfState` Pydantic model with phase, day, player roles, alive players, known roles, and computed winner
- use builtin generics and default alive players to all roles without validators
- let `WerewolfMachine` accept a `WerewolfState` model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0deee0810832b8310b7f8dc1b2f0f